### PR TITLE
Apply patch to fix redundant mem_results and missing commit_valid

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -143,6 +143,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   // eXtension interface
   cv32e40x_if_xif.cpu_commit xif_commit_if,
+  input  logic               xif_mem_valid_i,
+  input  logic               xif_mem_ready_i,
   input                      xif_csr_error_i
 );
 
@@ -241,6 +243,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_commit_if               ( xif_commit_if            ),
+    .xif_mem_valid_i             ( xif_mem_valid_i          ),
+    .xif_mem_ready_i             ( xif_mem_ready_i          ),
     .xif_csr_error_i             ( xif_csr_error_i          )
   );
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -130,6 +130,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   // eXtension interface
   cv32e40x_if_xif.cpu_commit xif_commit_if,
+  input  logic               xif_mem_valid_i,
+  input  logic               xif_mem_ready_i,
   input                      xif_csr_error_i
 );
 
@@ -1489,7 +1491,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           commit_valid_q <= 1'b0;
           commit_kill_q  <= 1'b0;
         end else begin
-          if ((ex_valid_i && wb_ready_i) || ctrl_fsm_o.kill_ex) begin
+          if ((ex_valid_i && wb_ready_i) || ctrl_fsm_o.kill_ex || (xif_mem_valid_i && xif_mem_ready_i)) begin
             commit_valid_q <= 1'b0;
             commit_kill_q  <= 1'b0;
           end else begin

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -576,6 +576,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_issue_if                 ( xif_issue_if              ),
+    .xif_mem_valid_i              ( xif_mem_if.mem_valid      ),
+    .xif_mem_ready_i              ( xif_mem_if.mem_ready      ),
     .xif_offloading_o             ( xif_offloading_id         )
   );
 
@@ -1005,6 +1007,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_commit_if                  ( xif_commit_if          ),
+    .xif_mem_valid_i                ( xif_mem_if.mem_valid   ),
+    .xif_mem_ready_i                ( xif_mem_if.mem_ready   ),
     .xif_csr_error_i                ( xif_csr_error_ex       )
   );
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -97,6 +97,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   // eXtension interface
   cv32e40x_if_xif.cpu_issue xif_issue_if,
+  input  logic              xif_mem_valid_i,
+  input  logic              xif_mem_ready_i,
   output logic              xif_offloading_o
 );
 
@@ -648,6 +650,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         id_ex_pipe_o.xif_meta.accepted      <= xif_insn_accept;
 
       end else if (ex_ready_i) begin
+        id_ex_pipe_o.instr_valid            <= 1'b0;
+      end else if (xif_mem_valid_i && xif_mem_ready_i) begin
         id_ex_pipe_o.instr_valid            <= 1'b0;
       end
     end

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -437,6 +437,10 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       end else if (id_ready_i) begin
         if_id_pipe_o.instr_valid      <= 1'b0;
       end
+      // Update the xif_id whenever the ID stage attempts to offload an instruction
+      if (id_ready_i && xif_offloading_id_i) begin
+        if_id_pipe_o.xif_id <= xif_id;
+      end
     end
   end
 


### PR DESCRIPTION
This PR is the same as https://github.com/openhwgroup/cv32e40x/pull/825 which solves https://github.com/openhwgroup/cv32e40x/issues/800 and https://github.com/openhwgroup/cv32e40x/issues/814.